### PR TITLE
Remove the use of legacy materials to specify the api version

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,6 +2,7 @@ name: ActionHealth
 main: com.zeshanaslam.actionhealth.Main
 version: 3.5.4
 softdepend: [PlaceholderAPI, MVdWPlaceholderAPI, WorldGuard, mcMMO, MythicMobs, LangUtils]
+api-version: 1.13
 commands:
   Actionhealth:
     description: Actionhealth main commands.

--- a/src/com/zeshanaslam/actionhealth/LookThread.java
+++ b/src/com/zeshanaslam/actionhealth/LookThread.java
@@ -7,27 +7,15 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 public class LookThread extends BukkitRunnable {
 
     private Main plugin;
-    private Set<Byte> transparentTypeIds;
     private TargetHelper targetHelper;
 
     public LookThread(Main plugin) {
         this.plugin = plugin;
         this.targetHelper = new TargetHelper(plugin);
-        this.transparentTypeIds = new TreeSet<>();
-
-        transparentTypeIds.add((byte) 0);
-        transparentTypeIds.add((byte) 20);
-        transparentTypeIds.add((byte) 95);
-        transparentTypeIds.add((byte) 102);
-        transparentTypeIds.add((byte) 160);
-        transparentTypeIds.add((byte) 8);
-        transparentTypeIds.add((byte) 9);
     }
 
     @Override
@@ -47,7 +35,7 @@ public class LookThread extends BukkitRunnable {
 
                     String name = plugin.healthUtil.getName(livingEntity, player);
 
-                    if (targetHelper.canSee(player, livingEntity.getLocation(), transparentTypeIds) && !plugin.healthUtil.isBlacklisted(livingEntity, name)) {
+                    if (targetHelper.canSee(player, livingEntity.getLocation()) && !plugin.healthUtil.isBlacklisted(livingEntity, name)) {
                         if (plugin.configStore.isUsingWhiteList()) {
                             if (!plugin.healthUtil.isWhiteListed(livingEntity, name)) {
                                 continue;

--- a/src/com/zeshanaslam/actionhealth/utils/TargetHelper.java
+++ b/src/com/zeshanaslam/actionhealth/utils/TargetHelper.java
@@ -9,9 +9,7 @@ import org.bukkit.util.BlockIterator;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * <p>Helper class for getting targets using various methods</p>
@@ -302,24 +300,11 @@ public class TargetHelper {
         }
     }
 
-    public Block getTarget(Location from, int distance, byte... transparentTypeIds) {
-        if (transparentTypeIds.length == 0) {
-            return getTarget(from, distance, (Set<Byte>) null);
-        } else {
-            Set<Byte> types = new HashSet<>(transparentTypeIds.length);
-            for (byte b : transparentTypeIds) types.add(b);
-            return getTarget(from, distance, types);
-        }
-    }
-
-    public Block getTarget(Location from, int distance, Set<Byte> transparentTypeIds) {
+    public Block getTarget(Location from, int distance) {
         BlockIterator itr = new BlockIterator(from, 0, distance);
         while (itr.hasNext()) {
             Block block = itr.next();
-            int id = block.getType().getId();
-            if (transparentTypeIds == null) {
-                if (id == 0) continue;
-            } else if (transparentTypeIds.contains((byte) id)) {
+            if (!block.getType().isOccluding()) {
                 continue;
             }
             return block;
@@ -327,19 +312,7 @@ public class TargetHelper {
         return null;
     }
 
-    public Block getTarget(LivingEntity from, int distance, Set<Byte> transparentTypeIds) {
-        return getTarget(from.getEyeLocation(), distance, transparentTypeIds);
-    }
-
-    public Block getTarget(LivingEntity from, int distance, byte... transparentTypeIds) {
-        return getTarget(from.getEyeLocation(), distance, transparentTypeIds);
-    }
-
-    public boolean canSee(LivingEntity from, Location to, Set<Byte> transparentTypeIds) {
-        return getTarget(from, (int) Math.ceil(from.getLocation().distance(to)), transparentTypeIds) == null;
-    }
-
-    public boolean canSee(LivingEntity from, Location to, byte... transparentTypeIds) {
-        return getTarget(from, (int) Math.ceil(from.getLocation().distance(to)), transparentTypeIds) == null;
+    public boolean canSee(LivingEntity from, Location to) {
+        return getTarget(from.getEyeLocation(), (int) Math.ceil(from.getLocation().distance(to))) == null;
     }
 }


### PR DESCRIPTION
Hello,

I have removed the use of the old material ID to be able to specify the `api-version`. This changes the original behavior, health can be seen through blocks such as leaves, stained glass or normal ice.
Closes #34